### PR TITLE
added content type restriction middleware, added unit tests.

### DIFF
--- a/server/rest/handler.go
+++ b/server/rest/handler.go
@@ -11,8 +11,13 @@ import (
 	"github.com/streamdp/ip-info/server"
 )
 
+const (
+	jsonContentType   = "application/json"
+	contentTypeHeader = "Content-Type"
+)
+
 func writeJsonResponse(w http.ResponseWriter, code int, response *domain.Response) (err error) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, jsonContentType)
 	w.WriteHeader(code)
 	_, err = w.Write(response.Bytes())
 	return err
@@ -48,6 +53,9 @@ func (s *Server) healthz() func(http.ResponseWriter, *http.Request) {
 func getHttpStatus(err error) int {
 	if err == nil {
 		return http.StatusOK
+	}
+	if errors.Is(err, errWrongContentType) {
+		return http.StatusNotImplemented
 	}
 	if errors.Is(err, server.ErrRateLimitExceeded) {
 		return http.StatusTooManyRequests

--- a/server/rest/main.go
+++ b/server/rest/main.go
@@ -44,7 +44,7 @@ func NewServer(locator server.Locator, l *log.Logger, limiter server.Limiter, cf
 }
 
 func (s *Server) Run() {
-	s.srv.Handler = s.initRouter()
+	s.srv.Handler = contentTypeRestrictionMW(s.l, s.initRouter())
 
 	if s.cfg.EnableLimiter {
 		s.srv.Handler = rateLimiterMW(s.limiter, s.l, s.srv.Handler)

--- a/server/rest/middleware.go
+++ b/server/rest/middleware.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -19,4 +21,21 @@ func rateLimiterMW(limiter server.Limiter, l *log.Logger, next http.Handler) htt
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+var errWrongContentType = errors.New("content type not implemented")
+
+func contentTypeRestrictionMW(l *log.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if c := r.Header.Get(contentTypeHeader); c != "" && c != jsonContentType {
+			err := fmt.Errorf("%w: %s", errWrongContentType, c)
+			if err = writeJsonResponse(w, getHttpStatus(err), domain.NewResponse(err, nil)); err != nil {
+				l.Println(err)
+			}
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+
 }

--- a/server/rest/middleware_test.go
+++ b/server/rest/middleware_test.go
@@ -1,0 +1,147 @@
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/streamdp/ip-info/domain"
+	"github.com/streamdp/ip-info/server"
+)
+
+func Test_rateLimiterMW(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *http.Request
+		limiter        server.Limiter
+		wantStatusCode int
+		wantError      bool
+	}{
+		{
+			name:           "client has reached its limits",
+			request:        httptest.NewRequest(http.MethodGet, "/client-ip", nil),
+			limiter:        &mockLimiter{err: server.ErrRateLimitExceeded},
+			wantStatusCode: http.StatusTooManyRequests,
+			wantError:      true,
+		},
+		{
+			name:           "client not limited",
+			request:        httptest.NewRequest(http.MethodGet, "/ip-info", nil),
+			limiter:        &mockLimiter{},
+			wantStatusCode: http.StatusOK,
+			wantError:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mw := rateLimiterMW(
+				tt.limiter,
+				log.New(io.Discard, "", log.LstdFlags),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+			)
+
+			w := httptest.NewRecorder()
+
+			mw.ServeHTTP(w, tt.request)
+
+			res := w.Result()
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(res.Body)
+
+			if res.StatusCode != tt.wantStatusCode {
+				t.Errorf("rateLimiterMW() = %d, want %d", res.StatusCode, tt.wantStatusCode)
+			}
+
+			if tt.wantError {
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("read body: expected no error, got: %v", err)
+				}
+
+				resp := domain.Response{}
+				_ = json.Unmarshal(body, &resp)
+
+				if resp.Err == "" {
+					t.Fatalf("response doesn't contain error: expected error, got: \"\"")
+				}
+			}
+		})
+	}
+}
+
+func Test_contentTypeRestrictionMW(t *testing.T) {
+	tests := []struct {
+		name           string
+		r              *http.Request
+		contentType    string
+		wantStatusCode int
+		wantError      bool
+	}{
+		{
+			name:           "content type not implemented",
+			r:              httptest.NewRequest(http.MethodGet, "/client-ip", nil),
+			contentType:    "application/xml",
+			wantStatusCode: http.StatusNotImplemented,
+			wantError:      true,
+		},
+		{
+			name:           "content type implemented",
+			r:              httptest.NewRequest(http.MethodGet, "/ip-info", nil),
+			contentType:    jsonContentType,
+			wantStatusCode: http.StatusOK,
+			wantError:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mw := contentTypeRestrictionMW(
+				log.New(io.Discard, "", log.LstdFlags),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+			)
+
+			w := httptest.NewRecorder()
+			tt.r.Header.Set(contentTypeHeader, tt.contentType)
+
+			mw.ServeHTTP(w, tt.r)
+
+			res := w.Result()
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(res.Body)
+
+			if res.StatusCode != tt.wantStatusCode {
+				t.Errorf("contentTypeRestrictionMW() = %d, want %d", res.StatusCode, tt.wantStatusCode)
+			}
+
+			if tt.wantError {
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("read body: expected no error, got: %v", err)
+				}
+
+				resp := domain.Response{}
+				_ = json.Unmarshal(body, &resp)
+
+				if resp.Err == "" {
+					t.Fatalf("response doesn't contain error: expected error, got: \"\"")
+				}
+			}
+		})
+	}
+}
+
+type mockLimiter struct {
+	err error
+}
+
+func (ml *mockLimiter) Limit(_ string) error {
+	return ml.err
+}

--- a/server/rest/middleware_test.go
+++ b/server/rest/middleware_test.go
@@ -78,21 +78,21 @@ func Test_rateLimiterMW(t *testing.T) {
 func Test_contentTypeRestrictionMW(t *testing.T) {
 	tests := []struct {
 		name           string
-		r              *http.Request
+		request        *http.Request
 		contentType    string
 		wantStatusCode int
 		wantError      bool
 	}{
 		{
 			name:           "content type not implemented",
-			r:              httptest.NewRequest(http.MethodGet, "/client-ip", nil),
+			request:        httptest.NewRequest(http.MethodGet, "/client-ip", nil),
 			contentType:    "application/xml",
 			wantStatusCode: http.StatusNotImplemented,
 			wantError:      true,
 		},
 		{
 			name:           "content type implemented",
-			r:              httptest.NewRequest(http.MethodGet, "/ip-info", nil),
+			request:        httptest.NewRequest(http.MethodGet, "/ip-info", nil),
 			contentType:    jsonContentType,
 			wantStatusCode: http.StatusOK,
 			wantError:      false,
@@ -108,9 +108,9 @@ func Test_contentTypeRestrictionMW(t *testing.T) {
 			)
 
 			w := httptest.NewRecorder()
-			tt.r.Header.Set(contentTypeHeader, tt.contentType)
+			tt.request.Header.Set(contentTypeHeader, tt.contentType)
 
-			mw.ServeHTTP(w, tt.r)
+			mw.ServeHTTP(w, tt.request)
 
 			res := w.Result()
 			defer func(Body io.ReadCloser) {


### PR DESCRIPTION
Implemented content type restriction middleware to allow only handled content types to be explicitly allowed.
```golang
func (s *Server) Run() {
	s.srv.Handler = contentTypeRestrictionMW(s.l, s.initRouter())
...

```
```bash
$ curl -v -H "Content-Type:  application/xml" 127.0.0.1:8080/client-ip
...
< HTTP/1.1 501 Not Implemented
< Content-Type: application/json
< Date: Tue, 08 Apr 2025 19:08:26 GMT
< Content-Length: 81
< 
{
  "error": "content type not implemented: application/xml",
  "content": null
* Connection #0 to host 127.0.0.1 left intact
}
```
  Implementation was covered by unit testing, as well as the rest of the http handlers.
```shell
$ go test  -count=100 -cover ./server/rest/... 
ok      github.com/streamdp/ip-info/server/rest 0.067s  coverage: 72.6% of statements
```