### PR TITLE
refactored contentTypeRestrictionMW()

### DIFF
--- a/server/rest/handler.go
+++ b/server/rest/handler.go
@@ -11,11 +11,6 @@ import (
 	"github.com/streamdp/ip-info/server"
 )
 
-const (
-	jsonContentType   = "application/json"
-	contentTypeHeader = "Content-Type"
-)
-
 func writeJsonResponse(w http.ResponseWriter, code int, response *domain.Response) (err error) {
 	w.Header().Set(contentTypeHeader, jsonContentType)
 	w.WriteHeader(code)


### PR DESCRIPTION
implemented settings up mw separately for every endpoint.
```golang
func (s *Server) initRouter() http.Handler {
	mux := http.NewServeMux()
	mux.HandleFunc("GET /ip-info", contentTypeRestrictionMW(s.l, s.ipInfo(false), jsonContentType))
	mux.HandleFunc("GET /client-ip", contentTypeRestrictionMW(s.l, s.ipInfo(true), jsonContentType))
	mux.HandleFunc("GET /healthz", contentTypeRestrictionMW(s.l, s.healthz(), textPlainContentType))

	return mux
}
```
implemented support for endpoints that handle multiple types.
```golang
contentTypeRestrictionMW(s.l, s.ipInfo(false), jsonContentType, textPlainContentType)


```